### PR TITLE
Update user guide on the behavior of `edit`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -137,6 +137,12 @@ Format: `list`
 
 Edits an existing person in the contacts.
 
+<div markdown="block" class="alert alert-info">:information_source: **Note:**
+The displayed view in StaffConnect will reset to the default view after the `edit` command is called.
+
+The changes made are displayed in the result display above the command box.
+</div>
+
 Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [m/MODULE] [f/FACULTY] [v/VENUE] [t/TAG]…​ [a/AVAILABILITY]…​`
 
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -137,10 +137,13 @@ Format: `list`
 
 Edits an existing person in the contacts.
 
-<div markdown="block" class="alert alert-info">:information_source: **Note:**
-The displayed view in StaffConnect will reset to the default view after the `edit` command is called.
+<div markdown="block" class="alert alert-info">
 
-The changes made are displayed in the result display above the command box.
+**:information_source: Notes:**<br>
+
+* The displayed view in StaffConnect will reset to the default view after the `edit` command is called.
+
+* The changes made are displayed in the result display above the command box.
 </div>
 
 Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [m/MODULE] [f/FACULTY] [v/VENUE] [t/TAG]…​ [a/AVAILABILITY]…​`


### PR DESCRIPTION
Closes #239 

> Explicitly specify the behavior of `edit` in the user guide.
> 
> > Observation:
> > After editing a person, the app will refresh and the person in focus will be changed to the first person no matter which person I am actually editing.
> 
> > The changes made are reflected as a message under the result display at the bottom.